### PR TITLE
Optimize shell startup time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,10 +17,10 @@ CI runs markdownlint on push/PR to main. Lint config is in `.mdlrc`.
 **Loading order (bash/zsh):**
 
 1. `~/.dotfiles_config` (optional early config, e.g. `SCM_PROVIDER="ado"`)
-2. `scripts/common.sh` — detects OS, sources `os_{macos,linux}.sh`, then loads all `scripts/*.sh`
-3. `scripts/path.sh` is loaded first (before other scripts)
-4. `scripts/github.sh` vs `scripts/ado.sh` — only one is loaded, controlled by `SCM_PROVIDER` env var (defaults to `github`)
-5. `~/.local_profile_overrides` (optional per-machine overrides, sourced last)
+1. `scripts/common.sh` — detects OS, sources `os_{macos,linux}.sh`, then loads all `scripts/*.sh`
+1. `scripts/path.sh` is loaded first (before other scripts)
+1. `scripts/github.sh` vs `scripts/ado.sh` — only one is loaded, controlled by `SCM_PROVIDER` env var (defaults to `github`)
+1. `~/.local_profile_overrides` (optional per-machine overrides, sourced last)
 
 **PowerShell:** `profile.ps1` dot-sources all `scripts/*.ps1` files. PowerShell scripts (`*.ps1`) and shell scripts (`*.sh`) coexist in `scripts/` — some features have parallel implementations (e.g. `ado.sh`/`ado.ps1`, `oh-my-posh.sh`/`oh-my-posh.ps1`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+Personal dotfiles for bash, zsh, and PowerShell. Shell configs are sourced (not symlinked for bash/zsh; symlinked for PowerShell). No build system or tests — just shell scripts.
+
+## CI
+
+CI runs markdownlint on push/PR to main. Lint config is in `.mdlrc`.
+
+## Architecture
+
+**Entry points:** `bashrc`, `zshrc`, `profile.ps1` — each sets `DOTFILES_DIR` and loads shared scripts.
+
+**Loading order (bash/zsh):**
+1. `~/.dotfiles_config` (optional early config, e.g. `SCM_PROVIDER="ado"`)
+2. `scripts/common.sh` — detects OS, sources `os_{macos,linux}.sh`, then loads all `scripts/*.sh`
+3. `scripts/path.sh` is loaded first (before other scripts)
+4. `scripts/github.sh` vs `scripts/ado.sh` — only one is loaded, controlled by `SCM_PROVIDER` env var (defaults to `github`)
+5. `~/.local_profile_overrides` (optional per-machine overrides, sourced last)
+
+**PowerShell:** `profile.ps1` dot-sources all `scripts/*.ps1` files. PowerShell scripts (`*.ps1`) and shell scripts (`*.sh`) coexist in `scripts/` — some features have parallel implementations (e.g. `ado.sh`/`ado.ps1`, `oh-my-posh.sh`/`oh-my-posh.ps1`).
+
+**Oh-My-Posh:** prompt theme is `rpunt.omp.json` (shared across all shells).
+
+## Workflow Rules
+
+- **Never commit to main.** Always create a feature branch first.
+
+## Key Conventions
+
+- Functions that need colored output call `colors()` from `misc.sh` first to set tput variables.
+- PATH manipulation uses `prepend_path`/`append_path` helpers in `path.sh` for idempotent additions.
+- 1Password CLI integration (`1password.sh`) provides `oplogin`, `getpassword`, `gettoken`, `getmfa` — used by `auth_gh_work`/`auth_gh_home` for GitHub auth switching.
+- `ado.sh` functions are stubs (echoing "using ADO") — the GitHub equivalents in `github.sh` are the active implementations.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ CI runs markdownlint on push/PR to main. Lint config is in `.mdlrc`.
 **Entry points:** `bashrc`, `zshrc`, `profile.ps1` — each sets `DOTFILES_DIR` and loads shared scripts.
 
 **Loading order (bash/zsh):**
+
 1. `~/.dotfiles_config` (optional early config, e.g. `SCM_PROVIDER="ado"`)
 2. `scripts/common.sh` — detects OS, sources `os_{macos,linux}.sh`, then loads all `scripts/*.sh`
 3. `scripts/path.sh` is loaded first (before other scripts)

--- a/bashrc
+++ b/bashrc
@@ -6,6 +6,11 @@ export DOTFILES_DIR="${DOTFILES_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pw
 # Load early config (e.g., SCM_PROVIDER="ado" for Azure DevOps laptops)
 test -f ~/.dotfiles_config && source ~/.dotfiles_config
 
+if type brew &>/dev/null; then
+  export BREW_PREFIX="$(brew --prefix)"
+  eval "$(brew shellenv)"
+fi
+
 # shellcheck source=/dev/null
 if [[ -f "${DOTFILES_DIR}/scripts/common.sh" ]]; then
   source "${DOTFILES_DIR}/scripts/common.sh"
@@ -13,25 +18,16 @@ fi
 
 # Anything bash-specific that truly can’t live in shared scripts:
 if [[ -n "$BASH_VERSION" ]]; then
-  if type brew &>/dev/null; then
-    eval "$($(which brew) shellenv)"
-  fi
 
   set -o vi
 
-  if [ -n "$BASH_VERSION" ]; then
-    bind "set completion-ignore-case on"
-    bind "set completion-map-case on"
-    bind "set show-all-if-ambiguous on"
+  bind "set completion-ignore-case on"
+  bind "set completion-map-case on"
+  bind "set show-all-if-ambiguous on"
 
-    # shopt -s autocd
-    shopt -s cdspell
-    shopt -s cdable_vars
-  fi
-
-  # POSH_THEMES_PATH=$(brew --prefix oh-my-posh)/themes
-  # eval "$(oh-my-posh completion bash)"
-  # eval "$(oh-my-posh init bash --config "$POSH_THEMES_PATH"/clean-detailed.omp.json | sed 's|\[\[ -v MC_SID \]\]|[[ -n "$MC_SID" ]]|')"
+  # shopt -s autocd
+  shopt -s cdspell
+  shopt -s cdable_vars
 fi
 
 # place any private configs in ~/.local_profile_overrides

--- a/scripts/aliases.sh
+++ b/scripts/aliases.sh
@@ -17,7 +17,7 @@ alias tplan="terraform plan"
 alias cocac="code ~/Documents/workspaces/cac.code-workspace"
 alias coterraform="code ~/Documents/workspaces/terraform.code-workspace"
 
-alias cr_start_single='cockroach start-single-node --store=$(brew --prefix)/var/cockroach/single --http-port=26256 --insecure --host=localhost'
+alias cr_start_single='cockroach start-single-node --store=${BREW_PREFIX}/var/cockroach/single --http-port=26256 --insecure --host=localhost'
 
 # still in beta
 # alias copilot='gh copilot'

--- a/scripts/misc.sh
+++ b/scripts/misc.sh
@@ -24,15 +24,10 @@ function weather() {
   curl wttr.in/"${1:-55328}"
 }
 
-# export ENABLE_FAST_GIT_PROMPT=0         # faster - don't use with ENABLE_GIT_PROMPT
-# if [ "$ENABLE_FAST_GIT_PROMPT" = 1 ]; then
-#   source "${HOME}/.git_bash_prompt"
-# fi
-
 function getaocinputs() {
   curl "https://adventofcode.com/$(date +%Y)/day/$(date +%-d)/input" --cookie "session=$(cat ~/.config/aoc/token)"
 }
 
 function sgrep() {
- grep -ir --exclude-dir="tfstate_backups" $1 | grep service_name
+ grep -ir --exclude-dir="tfstate_backups" "$1" | grep service_name
 }

--- a/scripts/oh-my-posh.sh
+++ b/scripts/oh-my-posh.sh
@@ -7,8 +7,6 @@ fi
 
 if [[ -n "$BREW_PREFIX" ]]; then
   POSH_THEMES_PATH="${BREW_PREFIX}/opt/oh-my-posh/themes"
-elif type brew &>/dev/null; then
-  POSH_THEMES_PATH="$(brew --prefix oh-my-posh)/themes"
 fi
 
 eval "$(oh-my-posh init "$DETECTED_SHELL" --config ${DOTFILES_DIR}/rpunt.omp.json | sed 's|\[\[ -v MC_SID \]\]|[[ -n "$MC_SID" ]]|')"

--- a/zshrc
+++ b/zshrc
@@ -22,11 +22,18 @@ if [[ -n "$ZSH_VERSION" ]]; then
 
   zstyle ':completion:*' matcher-list 'm:{a-z}={A-Za-z}'
 
-  # Lazy-load completions for faster startup
+  # Cache completions for faster startup
+  local cache_dir="${HOME}/.cache/zsh-completions"
+  [[ -d "$cache_dir" ]] || mkdir -p "$cache_dir"
   for bin in op roachdev roachprod workload-analyzer; do
     if command -v "$bin" &>/dev/null; then
-      eval "$($bin completion zsh)"
-      compdef "_$bin" "$bin"
+      local bin_path="$(command -v "$bin")"
+      local cache_file="${cache_dir}/_${bin}"
+      if [[ ! -f "$cache_file" || "$bin_path" -nt "$cache_file" ]]; then
+        "$bin" completion zsh > "$cache_file" 2>/dev/null
+      fi
+      source "$cache_file"
+      compdef "_${bin}" "$bin"
     fi
   done
 

--- a/zshrc
+++ b/zshrc
@@ -25,7 +25,7 @@ if [[ -n "$ZSH_VERSION" ]]; then
   # Cache completions for faster startup
   local cache_dir="${HOME}/.cache/zsh-completions"
   [[ -d "$cache_dir" ]] || mkdir -p "$cache_dir"
-  for bin in op roachdev roachprod workload-analyzer; do
+  for bin in op roachdev roachprod workload-analyzer workload-exporter; do
     if command -v "$bin" &>/dev/null; then
       local bin_path="$(command -v "$bin")"
       local cache_file="${cache_dir}/_${bin}"


### PR DESCRIPTION
## Summary
- Cache `BREW_PREFIX` in bashrc before `common.sh` loads, eliminating redundant `brew --prefix` calls across `go.sh`, `oh-my-posh.sh`, `cockroach_db.sh`, and `aliases.sh`
- Cache zsh completions to `~/.cache/zsh-completions/`, regenerating only when binaries change
- Remove dead code (commented-out oh-my-posh init, git prompt block, redundant `$BASH_VERSION` check)
- Fix unquoted variable in `sgrep`
- Add `CLAUDE.md`

## Test plan
- [x] Open a new bash shell and verify prompt loads correctly
- [x] Open a new zsh shell and verify prompt and completions work
- [x] Run `echo $BREW_PREFIX` in both shells to confirm it's set
- [x] Run `cr_start_single` alias and verify path resolves
- [x] Verify `sgrep "some term"` works with spaces in the argument