### PR TITLE
Implement ADO PR functions and fix script correctness issues

### DIFF
--- a/scripts/ado.ps1
+++ b/scripts/ado.ps1
@@ -11,6 +11,125 @@ function prlist {
   $(az repos pr list) | ConvertFrom-Json | Select-Object @{Name = 'ID'; Expression = { $_.pullRequestId } }, @{Name = 'Title'; Expression = { $_.title } } | Format-Table
 }
 
+function check_pr_approved {
+  param([Parameter(Mandatory)][int]$PullRequestId)
+  $reviewers = az repos pr reviewer list --id $PullRequestId | ConvertFrom-Json
+  @($reviewers | Where-Object { $_.vote -eq 10 }).Count
+}
+
+function check_pr_approvers {
+  param([Parameter(Mandatory)][int]$PullRequestId)
+  $reviewers = az repos pr reviewer list --id $PullRequestId | ConvertFrom-Json
+  $reviewers | Where-Object { $_.vote -eq 10 } | ForEach-Object { $_.displayName }
+}
+
+function check_pr_checks {
+  param([Parameter(Mandatory)][int]$PullRequestId)
+  $policies = az repos pr policy list --id $PullRequestId | ConvertFrom-Json
+  $failed = @($policies | Where-Object { $_.isBlocking -and $_.status -ne 'approved' })
+  return ($failed.Count -eq 0)
+}
+
+function check_pr_failed_checks {
+  param([Parameter(Mandatory)][int]$PullRequestId)
+  $policies = az repos pr policy list --id $PullRequestId | ConvertFrom-Json
+  $policies | Where-Object { $_.status -ne 'approved' } | ForEach-Object {
+    [PSCustomObject]@{
+      Policy = $_.configuration.type.displayName
+      Status = $_.status
+    }
+  }
+}
+
+function check_pr_merge_state {
+  param([Parameter(Mandatory)][int]$PullRequestId)
+  $pr = az repos pr show --id $PullRequestId | ConvertFrom-Json
+  $pr.mergeStatus
+}
+
+function check_pr_is_merged {
+  param([Parameter(Mandatory)][int]$PullRequestId)
+  $pr = az repos pr show --id $PullRequestId | ConvertFrom-Json
+  $pr.status
+}
+
+function review_pr {
+  param([Parameter(Mandatory)][int]$PullRequestId)
+
+  $pr = az repos pr show --id $PullRequestId | ConvertFrom-Json
+  if (-not $pr) {
+    Write-Host "Error: PR #$PullRequestId not found" -ForegroundColor Red
+    return
+  }
+
+  $approved = check_pr_approved $PullRequestId
+  if ($approved -gt 0) {
+    Write-Host "PR $PullRequestId is already approved by $approved reviewer(s), skipping." -ForegroundColor Yellow
+    return
+  }
+
+  Write-Host "Reviewing PR #$PullRequestId by $($pr.createdBy.displayName): $($pr.title)" -ForegroundColor Cyan
+  az repos pr show --id $PullRequestId
+
+  $showDiff = (Read-Host "Do you want to see the diff? (y/n)").ToLower()
+  if ($showDiff -eq 'y') {
+    $target = $pr.targetRefName -replace '^refs/heads/', ''
+    $source = $pr.sourceRefName -replace '^refs/heads/', ''
+    git diff "origin/$target...origin/$source"
+  }
+
+  $approve = (Read-Host "Do you approve PR ${PullRequestId}? (y/n/s for skip)").ToLower()
+  if ($approve -eq 'y') {
+    Write-Host "Approving PR #$PullRequestId..." -ForegroundColor Cyan
+    az repos pr set-vote --id $PullRequestId --vote approve
+    Write-Host "PR #$PullRequestId approved!" -ForegroundColor Green
+  }
+  elseif ($approve -eq 's') {
+    Write-Host "Skipping PR #$PullRequestId" -ForegroundColor Yellow
+  }
+  else {
+    Write-Host "PR #$PullRequestId not approved" -ForegroundColor Red
+  }
+}
+
+function approve_list {
+  param([Parameter(Mandatory)][string]$SourceFile)
+
+  if (-not (Test-Path $SourceFile)) {
+    Write-Host "Error: File '$SourceFile' not found" -ForegroundColor Red
+    return
+  }
+
+  Write-Host "Processing PRs from $SourceFile..." -ForegroundColor Cyan
+  Get-Content $SourceFile | ForEach-Object {
+    $number = [regex]::Match($_, '\d+').Value
+    if ($number) {
+      review_pr -PullRequestId ([int]$number)
+    }
+  }
+  Write-Host "All PRs from $SourceFile processed!" -ForegroundColor Green
+}
+
+function approve_for {
+  param([Parameter(Mandatory)][string]$Username)
+
+  $creator = switch ($Username) {
+    'shamer' { 'shamer-dd' }
+    'rpunt' { 'dd-rpunt' }
+    'jloar' { 'dd-jloar' }
+    'bkwon' { 'bryankwon-doordash' }
+    default {
+      Write-Host "Unknown user: $Username" -ForegroundColor Red
+      return
+    }
+  }
+
+  $prs = az repos pr list --creator $creator | ConvertFrom-Json
+  $prs | Where-Object { -not $_.isDraft } | ForEach-Object {
+    review_pr -PullRequestId $_.pullRequestId
+  }
+}
+
 function prbrowse {
   $currentBranch = git branch --show-current
   $prs = $(az repos pr list --source-branch $currentBranch) | ConvertFrom-Json

--- a/scripts/ado.ps1
+++ b/scripts/ado.ps1
@@ -25,7 +25,11 @@ function check_pr_approvers {
 
 function check_pr_checks {
   param([Parameter(Mandatory)][int]$PullRequestId)
-  $policies = az repos pr policy list --id $PullRequestId | ConvertFrom-Json
+  $policiesJson = az repos pr policy list --id $PullRequestId
+  if ($LASTEXITCODE -ne 0) {
+    throw "Failed to retrieve policy checks for PR #$PullRequestId."
+  }
+  $policies = $policiesJson | ConvertFrom-Json
   $failed = @($policies | Where-Object { $_.isBlocking -and $_.status -ne 'approved' })
   return ($failed.Count -eq 0)
 }

--- a/scripts/ado.sh
+++ b/scripts/ado.sh
@@ -27,7 +27,10 @@ function check_pr_checks() {
   fi
 
   local failed_count
-  failed_count=$(az repos pr policy list --id "$1" -o json | jq '[.[] | select(.isBlocking == true and .status != "approved")] | length')
+  if ! failed_count=$(az repos pr policy list --id "$1" -o json | jq '[.[] | select(.isBlocking == true and .status != "approved")] | length'); then
+    echo "Error: Failed to retrieve policy checks for PR $1" >&2
+    return 1
+  fi
   return $(( failed_count > 0 ? 1 : 0 ))
 }
 
@@ -318,6 +321,7 @@ function approve_list() {
 
   echo "${cyan}Processing PRs from $sourcefile...${reset}"
   for pr in $(cat "$sourcefile"); do
+    local number
     number=$(echo "$pr" | grep -o '[0-9]\+')
     review_pr "$number"
   done

--- a/scripts/ado.sh
+++ b/scripts/ado.sh
@@ -1,73 +1,61 @@
 # ADO PR automation functions
 
 function check_pr_approved() {
-  # if [ -z "$1" ]; then
-  #   echo "Error: PR number is required" >&2
-  #   return 1
-  # fi
+  if [ -z "$1" ]; then
+    echo "Error: PR number is required" >&2
+    return 1
+  fi
 
-  # # Check if PR exists first
-  # if ! gh pr view "$1" &>/dev/null; then
-  #   echo "Error: PR #$1 not found" >&2
-  #   return 1
-  # fi
-
-  # local approved_count=$(gh pr view "$1" --json reviews --jq '.reviews | map(select(.state == "APPROVED")) | length')
-  # echo $approved_count
-  echo "using ADO"
+  local approved_count
+  approved_count=$(az repos pr reviewer list --id "$1" -o json | jq '[.[] | select(.vote == 10)] | length')
+  echo "$approved_count"
 }
 
 function check_pr_approvers() {
-  # if [ -z "$1" ]; then
-  #   echo "Error: PR number is required" >&2
-  #   return 1
-  # fi
+  if [ -z "$1" ]; then
+    echo "Error: PR number is required" >&2
+    return 1
+  fi
 
-  # gh pr view "$1" --json reviews --jq '.reviews | map(select(.state == "APPROVED")) | .[].author.login' 2>/dev/null
-  echo "using ADO"
+  az repos pr reviewer list --id "$1" -o json | jq -r '.[] | select(.vote == 10) | .displayName'
 }
 
 function check_pr_checks() {
-  # if [ -z "$1" ]; then
-  #   echo "Error: PR number is required" >&2
-  #   return 1
-  # fi
+  if [ -z "$1" ]; then
+    echo "Error: PR number is required" >&2
+    return 1
+  fi
 
-  # # Check if PR exists first
-  # if ! gh pr view "$1" &>/dev/null; then
-  #   echo "Error: PR #$1 not found" >&2
-  #   return 1
-  # fi
-
-  # gh pr checks "$1" --required 1>/dev/null 2>&1
-  # rc=$?
-  # return $rc
-  echo "using ADO"
+  local failed_count
+  failed_count=$(az repos pr policy list --id "$1" -o json | jq '[.[] | select(.isBlocking == true and .status != "approved")] | length')
+  return $(( failed_count > 0 ? 1 : 0 ))
 }
 
 function check_pr_failed_checks() {
-  # if [ -z "$1" ]; then
-  #   echo "Error: PR number is required" >&2
-  #   return 1
-  # fi
+  if [ -z "$1" ]; then
+    echo "Error: PR number is required" >&2
+    return 1
+  fi
 
-  # gh pr view "$1" --json statusCheckRollup --jq '.statusCheckRollup[] | select(.state != "SUCCESS" and .state != null) | {context: .context, state: .state, targetUrl: .targetUrl}'
-  echo "using ADO"
+  az repos pr policy list --id "$1" -o json | jq '.[] | select(.status != "approved") | {policy: .configuration.type.displayName, status: .status}'
 }
 
 function check_pr_merge_state() {
-  # if [ -z "$1" ]; then
-  #   echo "Error: PR number is required" >&2
-  #   return 1
-  # fi
+  if [ -z "$1" ]; then
+    echo "Error: PR number is required" >&2
+    return 1
+  fi
 
-  # gh pr view "$1" --json mergeStateStatus --jq '.mergeStateStatus'
-  echo "using ADO"
+  az repos pr show --id "$1" -o json | jq -r '.mergeStatus'
 }
 
 function check_pr_is_merged() {
-  # gh pr view $1 --json state --jq '.state'
-  echo "using ADO"
+  if [ -z "$1" ]; then
+    echo "Error: PR number is required" >&2
+    return 1
+  fi
+
+  az repos pr show --id "$1" -o json | jq -r '.status'
 }
 
 function merge_mine() {
@@ -257,105 +245,106 @@ function hammer_away() {
 }
 
 function review_pr() {
-  # colors
+  colors
 
-  # if [ -z "$1" ]; then
-  #   echo "${red}Error: PR number is required${reset}" >&2
-  #   return 1
-  # fi
+  if [ -z "$1" ]; then
+    echo "${red}Error: PR number is required${reset}" >&2
+    return 1
+  fi
 
-  # local pr="$1"
+  local pr="$1"
 
-  # # Check if PR exists first
-  # if ! gh pr view "$pr" &>/dev/null; then
-  #   echo "${red}Error: PR #$pr not found${reset}" >&2
-  #   return 1
-  # fi
+  local pr_json
+  pr_json=$(az repos pr show --id "$pr" -o json 2>/dev/null)
+  if [ -z "$pr_json" ]; then
+    echo "${red}Error: PR #$pr not found${reset}" >&2
+    return 1
+  fi
 
-  # # if the pr is approved, skip it
-  # local approved=$(check_pr_approved $pr)
-  # if [[ $approved -gt 0 ]]; then
-  #   echo "${yellow}PR $pr is already approved by $approved reviewer(s), skipping.${reset}"
-  #   return 0
-  # fi
+  local approved
+  approved=$(check_pr_approved "$pr")
+  if [[ $approved -gt 0 ]]; then
+    echo "${yellow}PR $pr is already approved by $approved reviewer(s), skipping.${reset}"
+    return 0
+  fi
 
-  # # Get PR title to show with the prompt
-  # local title=$(gh pr view "$pr" --json title --jq '.title')
-  # local author=$(gh pr view "$pr" --json author --jq '.author.login')
+  local title author
+  title=$(echo "$pr_json" | jq -r '.title')
+  author=$(echo "$pr_json" | jq -r '.createdBy.displayName')
 
-  # # view the PR in terminal
-  # echo "${cyan}Reviewing PR #$pr by $author: $title${reset}"
-  # gh pr view --comments $pr
+  echo "${cyan}Reviewing PR #$pr by $author: $title${reset}"
+  az repos pr show --id "$pr"
 
-  # # Show the diff if requested
-  # echo -n "${cyan}Do you want to see the diff? (y/n) ${reset}"
-  # read show_diff
-  # show_diff=$(echo "$show_diff" | tr '[:upper:]' '[:lower:]')
+  echo -n "${cyan}Do you want to see the diff? (y/n) ${reset}"
+  read show_diff
+  show_diff=$(echo "$show_diff" | tr '[:upper:]' '[:lower:]')
 
-  # if [[ $show_diff == "y" ]]; then
-  #   gh pr diff $pr | less
-  # fi
+  if [[ $show_diff == "y" ]]; then
+    local target source
+    target=$(echo "$pr_json" | jq -r '.targetRefName | sub("^refs/heads/"; "")')
+    source=$(echo "$pr_json" | jq -r '.sourceRefName | sub("^refs/heads/"; "")')
+    git diff "origin/$target...origin/$source" | less
+  fi
 
-  # # prompt for approval; if I approve, merge the PR
-  # echo -n "${green}Do you approve PR $pr? (y/n/s for skip) ${reset}"
-  # read approve
-  # approve=$(echo "$approve" | tr '[:upper:]' '[:lower:]')
+  echo -n "${green}Do you approve PR $pr? (y/n/s for skip) ${reset}"
+  read approve
+  approve=$(echo "$approve" | tr '[:upper:]' '[:lower:]')
 
-  # if [[ $approve == "y" ]]; then
-  #   echo "${cyan}Approving PR #$pr...${reset}"
-  #   gh pr review -a $pr
-  #   echo "${green}PR #$pr approved!${reset}"
-  # elif [[ $approve == "s" ]]; then
-  #   echo "${yellow}Skipping PR #$pr${reset}"
-  # else
-  #   echo "${red}PR #$pr not approved${reset}"
-  # fi
-  echo "using ADO"
+  if [[ $approve == "y" ]]; then
+    echo "${cyan}Approving PR #$pr...${reset}"
+    az repos pr set-vote --id "$pr" --vote approve
+    echo "${green}PR #$pr approved!${reset}"
+  elif [[ $approve == "s" ]]; then
+    echo "${yellow}Skipping PR #$pr${reset}"
+  else
+    echo "${red}PR #$pr not approved${reset}"
+  fi
 }
 
 function approve_list() {
-  # if [ -z "$1" ]; then
-  #   echo "${red}Error: Source file is required${reset}" >&2
-  #   return 1
-  # fi
+  colors
 
-  # local sourcefile="$1"
+  if [ -z "$1" ]; then
+    echo "${red}Error: Source file is required${reset}" >&2
+    return 1
+  fi
 
-  # if [ ! -f "$sourcefile" ]; then
-  #   echo "${red}Error: File '$sourcefile' not found${reset}" >&2
-  #   return 1
-  # fi
+  local sourcefile="$1"
 
-  # echo "${cyan}Processing PRs from $sourcefile...${reset}"
-  # for pr in $(cat "$sourcefile"); do
-  #   number=$(echo $pr | grep -o '[0-9]\+')
-  #   review_pr $number
-  # done
-  # echo "${green}All PRs from $sourcefile processed!${reset}"
-  echo "using ADO"
+  if [ ! -f "$sourcefile" ]; then
+    echo "${red}Error: File '$sourcefile' not found${reset}" >&2
+    return 1
+  fi
+
+  echo "${cyan}Processing PRs from $sourcefile...${reset}"
+  for pr in $(cat "$sourcefile"); do
+    number=$(echo "$pr" | grep -o '[0-9]\+')
+    review_pr "$number"
+  done
+  echo "${green}All PRs from $sourcefile processed!${reset}"
 }
 
 function approve_for() {
-  # case $1 in
-  #   "shamer")
-  #     username="shamer-dd"
-  #     ;;
-  #   "rpunt")
-  #     username="dd-rpunt"
-  #     ;;
-  #   "jloar")
-  #     username="dd-jloar"
-  #     ;;
-  #   "bkwon")
-  #     username="bryankwon-doordash"
-  #     ;;
-  #   *)
-  #     echo "Unknown user: $1"
-  #     return 1
-  #     ;;
-  # esac
-  # for pr in $(gh pr list -A "$username" --json number,isDraft --jq '.[] | select(.isDraft == false) | .number'); do
-  #   review_pr $pr
-  # done
-  echo "using ADO"
+  local username
+  case $1 in
+    "shamer")
+      username="shamer-dd"
+      ;;
+    "rpunt")
+      username="dd-rpunt"
+      ;;
+    "jloar")
+      username="dd-jloar"
+      ;;
+    "bkwon")
+      username="bryankwon-doordash"
+      ;;
+    *)
+      echo "Unknown user: $1"
+      return 1
+      ;;
+  esac
+  for pr in $(az repos pr list --creator "$username" -o json | jq -r '.[] | select(.isDraft == false) | .pullRequestId'); do
+    review_pr "$pr"
+  done
 }

--- a/scripts/aws.sh
+++ b/scripts/aws.sh
@@ -1,13 +1,13 @@
 get_id() {
-    input=$@
+    input="$1"
     instance=$(aws ec2 describe-instances \
       --output json \
       --region us-west-2 \
       --filter "Name=private-ip-address,Values=$input" \
       --query 'Reservations[].Instances[]' | jq '.[0]')
-    instance_id=$(echo $instance | jq -r '.InstanceId')
-    crdb_cluster_name=$(echo $instance | jq -r '.Tags[] | select(.Key == "crdb_cluster_name") | .Value')
-    node_id=$(echo $instance | jq -r '.Tags[] | select(.Key == "node_id") | .Value')
+    instance_id=$(echo "$instance" | jq -r '.InstanceId')
+    crdb_cluster_name=$(echo "$instance" | jq -r '.Tags[] | select(.Key == "crdb_cluster_name") | .Value')
+    node_id=$(echo "$instance" | jq -r '.Tags[] | select(.Key == "node_id") | .Value')
     jq -n \
       --arg instance_id "$instance_id" \
       --arg crdb_cluster_name "$crdb_cluster_name" \
@@ -16,15 +16,15 @@ get_id() {
 }
 
 get_ip() {
-    input=$@
+    input="$1"
     instance=$(aws ec2 describe-instances \
       --output json \
       --region us-west-2 \
       --filter "Name=instance-id,Values=$input" \
       --query 'Reservations[].Instances[]' | jq '.[0]')
-    private_ip=$(echo $instance | jq -r '.NetworkInterfaces[].PrivateIpAddress')
-    crdb_cluster_name=$(echo $instance | jq -r '.Tags[] | select(.Key == "crdb_cluster_name") | .Value')
-    node_id=$(echo $instance | jq -r '.Tags[] | select(.Key == "node_id") | .Value')
+    private_ip=$(echo "$instance" | jq -r '.NetworkInterfaces[].PrivateIpAddress')
+    crdb_cluster_name=$(echo "$instance" | jq -r '.Tags[] | select(.Key == "crdb_cluster_name") | .Value')
+    node_id=$(echo "$instance" | jq -r '.Tags[] | select(.Key == "node_id") | .Value')
     jq -n \
       --arg private_ip "$private_ip" \
       --arg crdb_cluster_name "$crdb_cluster_name" \

--- a/scripts/cockroach_db.sh
+++ b/scripts/cockroach_db.sh
@@ -19,8 +19,8 @@ function cr_start_node() {
     return 1
   fi
 
-  listen_addr=$(echo $node | jq --arg nodenumber "$1" '. | .[$nodenumber] | .listen_addr')
-  http_addr=$(echo $node | jq --arg nodenumber "$1" '. | .[$nodenumber] | .http_addr')
+  listen_addr=$(echo "$node" | jq --arg nodenumber "$1" '. | .[$nodenumber] | .listen_addr')
+  http_addr=$(echo "$node" | jq --arg nodenumber "$1" '. | .[$nodenumber] | .http_addr')
   cockroach start \
     --insecure \
     --store="${BREW_PREFIX:-$(brew --prefix)}/var/cockroach/node${1}" \

--- a/scripts/github.sh
+++ b/scripts/github.sh
@@ -318,6 +318,7 @@ function approve_list() {
 
   echo "${cyan}Processing PRs from $sourcefile...${reset}"
   for pr in $(cat "$sourcefile"); do
+    local number
     number=$(echo "$pr" | grep -o '[0-9]\+')
     review_pr "$number"
   done

--- a/scripts/github.sh
+++ b/scripts/github.sh
@@ -6,14 +6,9 @@ function check_pr_approved() {
     return 1
   fi
 
-  # Check if PR exists first
-  if ! gh pr view "$1" &>/dev/null; then
-    echo "Error: PR #$1 not found" >&2
-    return 1
-  fi
-
-  local approved_count=$(gh pr view "$1" --json reviews --jq '.reviews | map(select(.state == "APPROVED")) | length')
-  echo $approved_count
+  local approved_count
+  approved_count=$(gh pr view "$1" --json reviews --jq '.reviews | map(select(.state == "APPROVED")) | length')
+  echo "$approved_count"
 }
 
 function check_pr_approvers() {
@@ -38,8 +33,7 @@ function check_pr_checks() {
   fi
 
   gh pr checks "$1" --required 1>/dev/null 2>&1
-  rc=$?
-  return $rc
+  return $?
 }
 
 function check_pr_failed_checks() {
@@ -61,7 +55,12 @@ function check_pr_merge_state() {
 }
 
 function check_pr_is_merged() {
-  gh pr view $1 --json state --jq '.state'
+  if [ -z "$1" ]; then
+    echo "Error: PR number is required" >&2
+    return 1
+  fi
+
+  gh pr view "$1" --json state --jq '.state'
 }
 
 function merge_mine() {
@@ -258,24 +257,24 @@ function review_pr() {
 
   local pr="$1"
 
-  # Check if PR exists first
-  if ! gh pr view "$pr" &>/dev/null; then
+  local pr_json
+  pr_json=$(gh pr view "$pr" --json title,author 2>/dev/null)
+  if [ -z "$pr_json" ]; then
     echo "${red}Error: PR #$pr not found${reset}" >&2
     return 1
   fi
 
-  # if the pr is approved, skip it
-  local approved=$(check_pr_approved $pr)
+  local approved
+  approved=$(check_pr_approved "$pr")
   if [[ $approved -gt 0 ]]; then
     echo "${yellow}PR $pr is already approved by $approved reviewer(s), skipping.${reset}"
     return 0
   fi
 
-  # Get PR title to show with the prompt
-  local title=$(gh pr view "$pr" --json title --jq '.title')
-  local author=$(gh pr view "$pr" --json author --jq '.author.login')
+  local title author
+  title=$(echo "$pr_json" | jq -r '.title')
+  author=$(echo "$pr_json" | jq -r '.author.login')
 
-  # view the PR in terminal
   echo "${cyan}Reviewing PR #$pr by $author: $title${reset}"
   gh pr view --comments $pr
 
@@ -319,13 +318,14 @@ function approve_list() {
 
   echo "${cyan}Processing PRs from $sourcefile...${reset}"
   for pr in $(cat "$sourcefile"); do
-    number=$(echo $pr | grep -o '[0-9]\+')
-    review_pr $number
+    number=$(echo "$pr" | grep -o '[0-9]\+')
+    review_pr "$number"
   done
   echo "${green}All PRs from $sourcefile processed!${reset}"
 }
 
 function approve_for() {
+  local username
   case $1 in
     "shamer")
       username="shamer-dd"

--- a/scripts/oh-my-posh.ps1
+++ b/scripts/oh-my-posh.ps1
@@ -8,16 +8,7 @@ if (Get-Command oh-my-posh -ErrorAction SilentlyContinue) {
     oh-my-posh init pwsh --config "${env:HOME}/dev/dotfiles/rpunt.omp.json" | iex
   }
 
-  if ($PSVersionTable.os -match "Windows") {
-    oh-my-posh init pwsh --config "${Env:HOMEDRIVE}${Env:HOMEPATH}\dev\dotfiles\rpunt.omp.json" | Invoke-Expression
-  }
-
-  # alternate for Windows, from https://gist.github.com/rkttu/3d286f711ebd7de239489fc3310a80cd
-  # for PowerShell (Windows)
-  if ([Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT) {
-    # $env:POSH_THEMES_PATH = Join-Path -Path (Get-Item -Path (Get-Command -Name 'oh-my-posh').Source).Directory.Parent.FullName -ChildPath 'themes'
-    # [scriptblock]::Create($(oh-my-posh completion powershell)).Invoke()
-    # oh-my-posh init pwsh --config "$env:POSH_THEMES_PATH/clean-detailed.omp.json" | iex
+  if ($PSVersionTable.os -match "Windows" -or [Environment]::OSVersion.Platform -eq [PlatformID]::Win32NT) {
     oh-my-posh init pwsh --config "${Env:HOMEDRIVE}${Env:HOMEPATH}\dev\dotfiles\rpunt.omp.json" | Invoke-Expression
   }
 } else {

--- a/scripts/oh-my-posh.sh
+++ b/scripts/oh-my-posh.sh
@@ -9,4 +9,4 @@ if [[ -n "$BREW_PREFIX" ]]; then
   POSH_THEMES_PATH="${BREW_PREFIX}/opt/oh-my-posh/themes"
 fi
 
-eval "$(oh-my-posh init "$DETECTED_SHELL" --config ${DOTFILES_DIR}/rpunt.omp.json | sed 's|\[\[ -v MC_SID \]\]|[[ -n "$MC_SID" ]]|')"
+eval "$(oh-my-posh init "$DETECTED_SHELL" --config "${DOTFILES_DIR}/rpunt.omp.json" | sed 's|\[\[ -v MC_SID \]\]|[[ -n "$MC_SID" ]]|')"


### PR DESCRIPTION
## Summary
- **ado.sh**: Replace all `echo "using ADO"` stubs with real `az repos pr` implementations for `check_pr_approved`, `check_pr_approvers`, `check_pr_checks`, `check_pr_failed_checks`, `check_pr_merge_state`, `check_pr_is_merged`, `review_pr`, `approve_list`, and `approve_for` (`merge_mine` and `hammer_away` remain as stubs)
- **ado.ps1**: Port the same functions to PowerShell using `az repos pr` CLI
- **github.sh**: Remove redundant `gh pr view` existence checks, combine 3 API calls into 1 in `review_pr`, add missing arg validation to `check_pr_is_merged`, fix unquoted variables, add `local` to `approve_for`'s `username`
- **aws.sh**: Quote `$instance` variables, use `$1` instead of `$@`
- **cockroach_db.sh**: Quote `$node` variable
- **oh-my-posh.ps1**: Merge duplicate Windows init blocks that caused double oh-my-posh initialization
- **oh-my-posh.sh**: Quote `${DOTFILES_DIR}` in eval line

## Test plan
- [x] `bash -n` syntax check passes on all modified `.sh` files
- [x] Verify shell startup with `source ~/.bashrc` / `source ~/.zshrc`
- [ ] Smoke-test an ADO function (e.g. `check_pr_is_merged <id>`) against a real PR