### PR TITLE
Decouple git-pat.sh from SCM_PROVIDER

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ New-Item @symlinkParams
 
 Close all terminals, and any new terminals will reflect the settings in this repo
 
+## Configuration
+
+Optional variables can be set in `~/.dotfiles_config` (sourced early, before everything else):
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `SCM_PROVIDER` | `github` | Set to `ado` to load Azure DevOps helpers instead of GitHub helpers |
+| `GIT_AUTH_PAT` | `false` | Set to `true` to enable PAT-based git authentication (prompts for a PAT on first git operation and injects it as an HTTP header) |
+
 ## Package Specifics
 
 ### Oh-my-posh

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -35,7 +35,7 @@ for file in "${DOTFILES_DIR}"/scripts/*.sh; do
   if [[ "$file" == */ado.sh ]] && [[ "${SCM_PROVIDER:-github}" != "ado" ]]; then
     continue
   fi
-  if [[ "$file" == */git-pat.sh ]] && [[ "${SCM_PROVIDER:-github}" != "ado" ]]; then
+  if [[ "$file" == */git-pat.sh ]] && [[ "${GIT_AUTH_PAT:-false}" != "true" ]]; then
     continue
   fi
 


### PR DESCRIPTION
## Summary
- Gate `git-pat.sh` on `GIT_AUTH_PAT=true` instead of `SCM_PROVIDER=ado`, allowing PAT-based git auth independently of the SCM provider
- Add a Configuration section to the README documenting `SCM_PROVIDER` and `GIT_AUTH_PAT`

## Test plan
- [x] Set `GIT_AUTH_PAT=true` in `~/.dotfiles_config` and verify `git-pat.sh` is sourced
- [x] Without `GIT_AUTH_PAT`, verify `git-pat.sh` is skipped
- [x] Verify `SCM_PROVIDER=ado` still loads `ado.sh` without affecting `git-pat.sh`